### PR TITLE
Reverted left-on mistake hotfix

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -252,7 +252,7 @@ int main() {
 		while(accumulator >= dT) {
 			if(particlepool.getSize() > 0) {
 				particlepool.updateForces(dT);
-				//particlepool.update(dT);
+				particlepool.update(dT);
 			}
 			
 


### PR DESCRIPTION
Due to some weird merging from awhile back, a mistake was accidentally left on which would've made the program not work as intended, here's a quick fix for that.